### PR TITLE
'a' on artist name adds all artist music to queue.

### DIFF
--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -75,6 +75,7 @@ func (ui *Ui) handlePageInput(event *tcell.EventKey) *tcell.EventKey {
 		}
 		return nil
 
+	// TODO (A) volume up with '+'; trivial, but needs to be a different patch so adding note
 	case '=':
 		// volume+
 		if err := ui.player.AdjustVolume(5); err != nil {

--- a/help_text.go
+++ b/help_text.go
@@ -10,14 +10,18 @@ r     add 50 random songs to queue
 `
 
 const helpPageBrowser = `
-ENTER play song (clears current queue)
-a     add album or song to queue
-A     add song to playlist
-y     toggle star on song/album
-R     refresh the list
-/     Search artists
-n     Continue search forward
-N     Continue search backwards
+artist tab
+  R     refresh the list
+  /     Search artists
+  a     Add all artist songs to queue
+  n     Continue search forward
+  N     Continue search backwards
+song tab
+  ENTER play song (clears current queue)
+  a     add album or song to queue
+  A     add song to playlist
+  y     toggle star on song/album
+  R     refresh the list
 ESC   Close search
 `
 

--- a/page_browser.go
+++ b/page_browser.go
@@ -98,6 +98,9 @@ func (ui *Ui) createBrowserPage(indexes *[]subsonic.SubsonicIndex) *BrowserPage 
 		}
 
 		switch event.Rune() {
+		case 'a':
+			browserPage.handleAddArtistToQueue()
+			return nil
 		case '/':
 			browserPage.showSearchField(true)
 			browserPage.search()
@@ -233,6 +236,23 @@ func (b *BrowserPage) UpdateStars() {
 	if b.currentDirectory != nil {
 		b.handleEntitySelected(b.currentDirectory.Id)
 	}
+}
+
+func (b *BrowserPage) handleAddArtistToQueue() {
+	currentIndex := b.artistList.GetCurrentItem()
+	if currentIndex < 0 {
+		return
+	}
+
+	for _, entity := range b.currentDirectory.Entities {
+		if entity.IsDirectory {
+			b.addDirectoryToQueue(&entity)
+		} else {
+			b.ui.addSongToQueue(&entity)
+		}
+	}
+
+	b.ui.queuePage.UpdateQueue()
 }
 
 func (b *BrowserPage) handleAddEntityToQueue() {

--- a/stmps.go
+++ b/stmps.go
@@ -64,6 +64,7 @@ func main() {
 		fmt.Printf("Error fetching indexes from server: %s\n", err)
 		os.Exit(1)
 	}
+	// TODO (B) loading playlists can take a long time on e.g. gonic if there are a lot of them; can it be done in the background?
 	playlistResponse, err := connection.GetPlaylists()
 	if err != nil {
 		fmt.Printf("Error fetching indexes from server: %s\n", err)

--- a/widget_help.go
+++ b/widget_help.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rivo/tview"
 )
 
+// FIXME (A) invoking help and the dismissing it ('q') dismisses it forever (it can't be called back up)
 type HelpWidget struct {
 	Root *tview.Flex
 


### PR DESCRIPTION
'a' works everywhere in the browser now, meaning 'a' when an artist is selected will recursively add everything by that artist.

While updating the help text for this feature, I noticed that it wasn't clear that bindings are specific to the tab: '/' doesn't work when the cursor is in the entities tab, for instance. This patch also includes a minor clarification telling the user in which tabs which keys work.