### PR TITLE
'+' also increases volume

### DIFF
--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -75,7 +75,7 @@ func (ui *Ui) handlePageInput(event *tcell.EventKey) *tcell.EventKey {
 		}
 		return nil
 
-	case '=':
+	case '+', '=':
 		// volume+
 		if err := ui.player.AdjustVolume(5); err != nil {
 			ui.logger.PrintError("handlePageInput: AdjustVolume+", err)

--- a/help_text.go
+++ b/help_text.go
@@ -1,12 +1,12 @@
 package main
 
 const helpPlayback = `
-p     play/pause
-P     stop
->     next song
--/=   volume down/volume up
-,/.   seek -10/+10 seconds
-r     add 50 random songs to queue
+p      play/pause
+P      stop
+>      next song
+-/=(+) volume down/volume up
+,/.    seek -10/+10 seconds
+r      add 50 random songs to queue
 `
 
 const helpPageBrowser = `

--- a/page_browser.go
+++ b/page_browser.go
@@ -82,6 +82,7 @@ func (ui *Ui) createBrowserPage(indexes *[]subsonic.SubsonicIndex) *BrowserPage 
 		AddItem(browserPage.artistList, 0, 1, true).
 		AddItem(browserPage.entityList, 0, 1, false)
 
+	// TODO (A) add search-for-song, if feasible. Might be able to do server-side then drill-down, but we might also have all entities cached on the client already. To investigate.
 	browserPage.Root = tview.NewFlex().SetDirection(tview.FlexRow)
 	browserPage.showSearchField(false) // add artist/search items
 


### PR DESCRIPTION
Makes it orthogonal to '-', and more consistent with other program key bingings where volume keys are +/-.

This has been driving me nuts forever. '=' is not an intuitive inverse for '-', and seems chosen because of someone's keyboard layout.

**Note** there will be a merge conflict with one of my other commits, because I added a todo comment near this change. The conflict resolution is to remove the block with the comment. It's minor, but it's there :-/