### PR TITLE
Fixes index panic on refresh operation.

### DIFF
--- a/page_browser.go
+++ b/page_browser.go
@@ -136,7 +136,9 @@ func (ui *Ui) createBrowserPage(indexes *[]subsonic.SubsonicIndex) *BrowserPage 
 	})
 
 	browserPage.artistList.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
-		browserPage.handleEntitySelected(browserPage.artistIdList[index])
+		if index < len(browserPage.artistIdList) {
+			browserPage.handleEntitySelected(browserPage.artistIdList[index])
+		}
 	})
 
 	// "add to playlist" modal


### PR DESCRIPTION
There is a narrow edge case when stmp is started on a Subsonic server that has no music indexed, and then music is added, and then stmp is refreshed with `r`. If this happens, stmp will panic on an index-out-of-bounds errror. This patch fixes that.