### PR TITLE
Fixes #8, help dialog can be shown exactly once

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -122,7 +122,13 @@ func InitGui(indexes *[]subsonic.SubsonicIndex,
 	// help box modal
 	ui.helpModal = makeModal(ui.helpWidget.Root, 80, 30)
 	ui.helpWidget.Root.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		ui.CloseHelp()
+		// Belts and suspenders. After the dialog is shown, this function will
+		// _always_ be called. Therefore, check to ensure it's actually visible
+		// before triggering on events. Also, don't close on every key, but only
+		// ESC, like the help text says.
+		if ui.helpWidget.visible && (event.Key() == tcell.KeyEscape) {
+			ui.CloseHelp()
+		}
 		return event
 	})
 
@@ -188,10 +194,13 @@ func (ui *Ui) ShowHelp() {
 	ui.helpWidget.RenderHelp(activePage)
 
 	ui.pages.ShowPage(PageHelpBox)
+	ui.pages.SendToFront(PageHelpBox)
 	ui.app.SetFocus(ui.helpModal)
+	ui.helpWidget.visible = true
 }
 
 func (ui *Ui) CloseHelp() {
+	ui.helpWidget.visible = false
 	ui.pages.HidePage(PageHelpBox)
 }
 

--- a/widget_help.go
+++ b/widget_help.go
@@ -12,6 +12,9 @@ type HelpWidget struct {
 	helpBook                *tview.Flex
 	leftColumn, rightColumn *tview.TextView
 
+	// visible reflects whether the modal is shown
+	visible bool
+
 	// external references
 	ui *Ui
 }
@@ -31,16 +34,9 @@ func (ui *Ui) createHelpWidget() (m *HelpWidget) {
 	m.helpBook = tview.NewFlex().
 		SetDirection(tview.FlexColumn)
 
-	// button at the bottom
-	closeButton := tview.NewButton("Close")
-	closeButton.SetSelectedFunc(func() {
-		ui.CloseHelp()
-	})
-
 	m.Root = tview.NewFlex().
 		SetDirection(tview.FlexRow).
-		AddItem(m.helpBook, 0, 1, false).
-		AddItem(closeButton, 1, 0, true)
+		AddItem(m.helpBook, 0, 1, false)
 
 	m.Root.Box.SetBorder(true).SetTitle(" Help ")
 


### PR DESCRIPTION
See https://github.com/rivo/tview/issues/986.

This also removes the "close" button since it no longer has a use. It also ensures the help dialog is being brought to the front.