### PR TITLE
Customizable number of random songs added to queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ plaintext = true  # Use 'legacy' unsalted password authentication (default: fals
 [server]
 host = 'https://your-subsonic-host.tld'
 scrobble = true  # Use Subsonic scrobbling for last.fm/ListenBrainz (default: false)
+
+[client]
+random-songs = 50
 ```
 
 ## Usage

--- a/stmps.go
+++ b/stmps.go
@@ -105,7 +105,7 @@ func main() {
 	connection.Host = viper.GetString("server.host")
 	connection.PlaintextAuth = viper.GetBool("auth.plaintext")
 	connection.Scrobble = viper.GetBool("server.scrobble")
-	connection.RandomSongNumber = viper.GetString("client.random-songs")
+	connection.RandomSongNumber = viper.GetUint("client.random-songs")
 
 	indexResponse, err := connection.GetIndexes()
 	if err != nil {

--- a/stmps.go
+++ b/stmps.go
@@ -105,6 +105,7 @@ func main() {
 	connection.Host = viper.GetString("server.host")
 	connection.PlaintextAuth = viper.GetBool("auth.plaintext")
 	connection.Scrobble = viper.GetBool("server.scrobble")
+	connection.RandomSongNumber = viper.GetString("client.random-songs")
 
 	indexResponse, err := connection.GetIndexes()
 	if err != nil {

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/spezifisch/stmps/logger"
+	"github.com/spf13/viper"
 )
 
 type SubsonicConnection struct {
@@ -242,7 +243,11 @@ func (connection *SubsonicConnection) GetMusicDirectory(id string) (*SubsonicRes
 func (connection *SubsonicConnection) GetRandomSongs() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
 	// Let's get 50 random songs, default is 10
-	query.Set("size", "50")
+	if viper.IsSet("client.random-songs"){
+		query.Set("size", viper.GetString("client.random-songs"))
+	} else {
+		query.Set("size", "50")
+	}
 	requestUrl := connection.Host + "/rest/getRandomSongs" + "?" + query.Encode()
 	resp, err := connection.getResponse("GetRandomSongs", requestUrl)
 	if err != nil {

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -20,7 +20,7 @@ type SubsonicConnection struct {
 	Host          		string
 	PlaintextAuth 		bool
 	Scrobble      		bool
-	RandomSongNumber	string
+	RandomSongNumber	uint
 
 	clientName    		string
 	clientVersion 		string
@@ -242,10 +242,10 @@ func (connection *SubsonicConnection) GetMusicDirectory(id string) (*SubsonicRes
 
 func (connection *SubsonicConnection) GetRandomSongs() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
-	// Try loading the number of random songs from the config file, if not, default to 50
-	if connection.RandomSongNumber != "" {
-		query.Set("size", connection.RandomSongNumber)
-	} else {
+	// Try loading the number of random songs from the config file (and clamp it to 500) if not, default to 50
+	if connection.RandomSongNumber > 0 && connection.RandomSongNumber < 500 {
+		query.Set("size", strconv.FormatInt(int64(connection.RandomSongNumber), 10))
+	} else {	
 		query.Set("size", "50")
 	}
 	requestUrl := connection.Host + "/rest/getRandomSongs" + "?" + query.Encode()

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -12,21 +12,21 @@ import (
 	"strings"
 
 	"github.com/spezifisch/stmps/logger"
-	"github.com/spf13/viper"
 )
 
 type SubsonicConnection struct {
-	Username      string
-	Password      string
-	Host          string
-	PlaintextAuth bool
-	Scrobble      bool
+	Username      		string
+	Password      		string
+	Host          		string
+	PlaintextAuth 		bool
+	Scrobble      		bool
+	RandomSongNumber	string
 
-	clientName    string
-	clientVersion string
+	clientName    		string
+	clientVersion 		string
 
-	logger         logger.LoggerInterface
-	directoryCache map[string]SubsonicResponse
+	logger         		logger.LoggerInterface
+	directoryCache 		map[string]SubsonicResponse
 }
 
 func Init(logger logger.LoggerInterface) *SubsonicConnection {
@@ -242,9 +242,9 @@ func (connection *SubsonicConnection) GetMusicDirectory(id string) (*SubsonicRes
 
 func (connection *SubsonicConnection) GetRandomSongs() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
-	// Let's get 50 random songs, default is 10
-	if viper.IsSet("client.random-songs"){
-		query.Set("size", viper.GetString("client.random-songs"))
+	// Try loading the number of random songs from the config file, if not, default to 50
+	if connection.RandomSongNumber != "" {
+		query.Set("size", connection.RandomSongNumber)
 	} else {
 		query.Set("size", "50")
 	}


### PR DESCRIPTION
Hello!

I'd like to share (what I think is) a useful feature - the ability to customize the number of random songs that go into a queue.

The `random-songs` setting under `[client]` in the `stmp.toml` config file is read and if no such setting is found, it defaults to 50.

I'm very new at Go, so feel free to point out any wrongdoings!

![stmps](https://github.com/user-attachments/assets/06aafea5-1952-4062-a530-650a4ff12c19)
