### PR TITLE
Added similar artist/album/song feature via `getSimilarSongs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These controls are accessible from any view:
 - `/`: Search artists
 - `n`: Continue search forward
 - `N`: Continue search backward
-- `S`: Add similar songs to playlist
+- `S`: Add similar artist/song/album to playlist
 
 ### Queue Controls
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These controls are accessible from any view:
 - `/`: Search artists
 - `n`: Continue search forward
 - `N`: Continue search backward
+- `S`: Add similar songs to playlist
 
 ### Queue Controls
 

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -37,7 +37,7 @@ func (ui *Ui) handlePageInput(event *tcell.EventKey) *tcell.EventKey {
 
 	case 'r':
 		// add random songs to queue
-		ui.handleAddRandomSongs()
+		ui.handleAddRandomSongs("", "random")
 
 	case 'D':
 		// clear queue and stop playing
@@ -117,18 +117,25 @@ func (ui *Ui) Quit() {
 	ui.app.Stop()
 }
 
-func (ui *Ui) handleAddRandomSongs() {
-	ui.addRandomSongsToQueue()
+func (ui *Ui) handleAddRandomSongs(Id string, randomType string) {
+	ui.addRandomSongsToQueue(Id, randomType)
 	ui.queuePage.UpdateQueue()
 }
 
-func (ui *Ui) addRandomSongsToQueue() {
-	response, err := ui.connection.GetRandomSongs()
+func (ui *Ui) addRandomSongsToQueue(Id string, randomType string) {
+	response, err := ui.connection.GetRandomSongs(Id, randomType)
 	if err != nil {
 		ui.logger.Printf("addRandomSongsToQueue %s", err.Error())
 	}
-	for _, e := range response.RandomSongs.Song {
-		ui.addSongToQueue(&e)
+	switch randomType{
+		case "random":
+			for _, e := range response.RandomSongs.Song {
+				ui.addSongToQueue(&e)
+			}
+		case "similar":
+			for _, e := range response.SimilarSongs.Song {
+				ui.addSongToQueue(&e)
+			}
 	}
 }
 

--- a/page_browser.go
+++ b/page_browser.go
@@ -114,6 +114,8 @@ func (ui *Ui) createBrowserPage(indexes *[]subsonic.SubsonicIndex) *BrowserPage 
 			browserPage.showSearchField(true)
 			browserPage.searchPrev()
 			return nil
+		case 'S':
+			browserPage.handleAddRandomSongs("similar")
 		case 'R':
 			goBackTo := browserPage.artistList.GetCurrentItem()
 			// REFRESH artists
@@ -209,6 +211,9 @@ func (ui *Ui) createBrowserPage(indexes *[]subsonic.SubsonicIndex) *BrowserPage 
 			browserPage.handleEntitySelected(browserPage.artistIdList[artistIdx])
 			return nil
 		}
+		if event.Rune() == 'S' {	
+			browserPage.handleAddRandomSongs("similar")
+		}
 		return event
 	})
 
@@ -256,6 +261,23 @@ func (b *BrowserPage) handleAddArtistToQueue() {
 
 	b.ui.queuePage.UpdateQueue()
 }
+
+func (b *BrowserPage) handleAddRandomSongs(randomType string) {
+	currentIndex := b.entityList.GetCurrentItem()
+	if b.currentDirectory.Parent != "" {
+		// account for [..] entry that we show, see handleEntitySelected()
+		currentIndex--
+	}
+	if currentIndex < 0 {
+		return
+	}
+
+	entity := b.currentDirectory.Entities[currentIndex]
+
+	b.ui.addRandomSongsToQueue(entity.Id, randomType)
+	b.ui.queuePage.UpdateQueue()
+}
+
 
 func (b *BrowserPage) handleAddEntityToQueue() {
 	currentIndex := b.entityList.GetCurrentItem()


### PR DESCRIPTION
Here's a neat feature: similar songs (or artist radio). This uses Subsonic's `getSimilarSongs`. It gets the selected artst, album or song ID, and gets and adds a number of (defined by `random-songs` in `stmp.toml`) songs to the queue.

It uses the `S` keyboard shortcut in the browser view.

I used a switch in case we want to use `getSimilarSongs2` or other features in the future.

One issue is that there is quite a delay when using `getSimilarSongs` - especially for artists or albums (works okay for songs). Not sure if this is a Subsonic thing.