### PR TITLE
Fixes #21; playlists are loaded in the background

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -71,7 +71,6 @@ const (
 )
 
 func InitGui(indexes *[]subsonic.SubsonicIndex,
-	playlists *[]subsonic.SubsonicPlaylist,
 	connection *subsonic.SubsonicConnection,
 	player *mpvplayer.Player,
 	logger *logger.Logger,
@@ -82,7 +81,7 @@ func InitGui(indexes *[]subsonic.SubsonicIndex,
 		eventLoop: nil, // initialized by initEventLoops()
 		mpvEvents: make(chan mpvplayer.UiEvent, 5),
 
-		playlists:   *playlists,
+		playlists:   []subsonic.SubsonicPlaylist{},
 		connection:  connection,
 		player:      player,
 		logger:      logger,
@@ -175,6 +174,8 @@ func InitGui(indexes *[]subsonic.SubsonicIndex,
 	ui.app.SetRoot(rootFlex, true).
 		SetFocus(rootFlex).
 		EnableMouse(true)
+
+	ui.playlistPage.UpdatePlaylists()
 
 	return ui
 }

--- a/stmps.go
+++ b/stmps.go
@@ -113,13 +113,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO (B) loading playlists can take a long time on e.g. gonic if there are a lot of them; can it be done in the background?
-	playlistResponse, err := connection.GetPlaylists()
-	if err != nil {
-		fmt.Printf("Error fetching indexes from server: %s\n", err)
-		os.Exit(1)
-	}
-
 	if *list {
 		fmt.Printf("Index response:\n")
 		fmt.Printf("  Directory: %s\n", indexResponse.Directory.Name)
@@ -134,7 +127,12 @@ func main() {
 		for _, pl := range indexResponse.Indexes.Index {
 			fmt.Printf("    %s\n", pl.Name)
 		}
-		fmt.Printf("Playlist response:\n")
+		fmt.Printf("Playlist response: (this can take a while)\n")
+		playlistResponse, err := connection.GetPlaylists()
+		if err != nil {
+			fmt.Printf("Error fetching indexes from server: %s\n", err)
+			os.Exit(1)
+		}
 		fmt.Printf("  Directory: %s\n", playlistResponse.Directory.Name)
 		fmt.Printf("  Status: %s\n", playlistResponse.Status)
 		fmt.Printf("  Error: %s\n", playlistResponse.Error.Message)
@@ -181,7 +179,6 @@ func main() {
 	}
 
 	ui := InitGui(&indexResponse.Indexes.Index,
-		&playlistResponse.Playlists.Playlists,
 		connection,
 		player,
 		logger,

--- a/widget_help.go
+++ b/widget_help.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rivo/tview"
 )
 
-// FIXME (A) invoking help and the dismissing it ('q') dismisses it forever (it can't be called back up)
 type HelpWidget struct {
 	Root *tview.Flex
 


### PR DESCRIPTION
There are two main components of this fix. The first is trivial: rather than calling `GetPlaylists()` up front in the GUI init, the playlists page is initialized empty. We then immediately call `UpdatePlaylists()` which forks off the call in the background and updates the playlists page when the server finally responds with all of the content.

The second component is the progress display in the UI. Since we can not tell from the Subsonic API how long the operation will take, a spinner is implemented on the "playlists" menu item. This runs until the operation is complete, at which point the menu is reset to the standard label.

Reproducing this may require specific conditions. #21 is a pain for me because my Subsonic server is Gonic, and the `GetPlaylists` call on the server side does a recursive load of all playlists and song metadata on each call, reloading from disk every time.  As you can see in the screencast below, on my server with a few dozen playlists, some of which are quite large, this can take over half a minute. Without this patch, stmps is hung pre-UI waiting for the server response.

To reproduce this:
1. Start with at least a few songs in the music lib
2. Write a script that creates a few dozen playlists -- the naming doesn't matter -- each containing all of the songs in the library 
3. Run gonic with the library and playlists
4. Run stmps against that gonic server

_Theoretically_, this should not interfere with the user _using_ the playlists during a reload; playlist reloading can happen when the user adds songs to a playlist or so forth; any playlist list reload will trigger this new behavior, during which the UI remains responsive. This is visible in the screencast at t:16s, when I switch from the browser to the playlist page -- the menu is appropriately updated with the formatting, although it's difficult to discern in the cast.

I've also run this against an empty gonic interface with no playlists, and confirmed that it doesn't, e.g., leave weird artifacts if there's no server latency.

https://asciinema.org/a/cBH5hCOa2nrzfzqpdcM7oDJ25

There are a couple of considerations -- improvements or possible changes to the implementation:

1. There's some hardcoding of the playlists menu item, in particular, the code **expects** the playlists pane to be the third in the menu. Additional code to derive this, or some `const`s to abstract it would be better proof against future changes; I didn't have a strong opinion about which direction to go, so it's just hard coded. This bugs me the most.
2. The spinner is based on UTF-8 braille character runes; this will therefore only work if the terminal font includes those code points. It would be _safer_ to use the age-old `\|/-` sequence, although where do we stop assuming the LCD? There are many other spinner character sequences, several of which would be more obvious -- the spinner I chose is _not_ particularly attention-demanding, IMO, but the braille characters are a fairly safe code point to depend upon, ASCII being the only more reliable (but ugly) option.
3. I did not make any changes to the README about this feature. But, then, not every little feature is in the README, so maybe this is OK.
4. I tried to bullet-proof the hell out of the code, since it introduces a fair amount of concurrency; there are mutexes and liberal use of the **tcell** `QueueUpdateDraw` function. Most of it is probably unnecessary, but also, none of it is in critical path loops and the overhead is dwarfed by network/server latencies.
5. The menu label formatting is annoyingly repetitive -- 7 lines of nearly identical code appear in 3 places, and one of those is dangerously in a different file. I was close to creating a convenience function, but it's right on the margin of what I consider overengineered vs cleaner. I could be convinced to pull it out into a convenience function, but it's currently not.  The code in question are [here](https://github.com/spezifisch/stmps/compare/main...xxxserxxx:stmp:progressive-playlists#diff-ff46999de1feb743a1f894f5eddfe281e4b662f728a4033504d534ee48a7442bR211), [here](https://github.com/spezifisch/stmps/compare/main...xxxserxxx:stmp:progressive-playlists#diff-ff46999de1feb743a1f894f5eddfe281e4b662f728a4033504d534ee48a7442bR226), and [here](https://github.com/spezifisch/stmps/blob/main/widget_menu.go#L104).