### PR TITLE
Makes the spinner configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ scrobble = true  # Use Subsonic scrobbling for last.fm/ListenBrainz (default: fa
 
 [client]
 random-songs = 50
+
+[ui]
+spinner = '▁▂▃▄▅▆▇█▇▆▅▄▃▂▁'
 ```
 
 ## Usage
@@ -115,6 +118,20 @@ These controls are accessible from any view:
 - `n`: New playlist
 - `d`: Delete playlist
 - `a`: Add playlist or song to queue
+
+On servers with a large number of songs in the playlists, Subsonic can take a while to respond to a request for a list. stmps therefore loads playlists in the background, and will display a spinner next to the "playlist" tab label at the bottom. This spinner can be configured with the `ui.spinner` option in the config file. Some ideas are:
+
+```toml
+spinner = '▁▂▃▄▅▆▇█▇▆▅▄▃▁'
+spinner = '⠁⠂⠄⡀⢀⠠⠐⠈'
+spinner = '|/-\'
+spinner = '▖▘'
+spinner = '▖▌▘'
+spinner = '┤┘┴└├┌┬┐'
+spinner = '⣾⣽⣻⢿⡿⣟⣯⣷'
+```
+
+The default is `▉▊▋▌▍▎▏▎▍▌▋▊▉`. Set only one of these at a time, and the glyphs must exist in the font that the terminal running stmps is using.
 
 ## Advanced Configuration and Features
 

--- a/page_playlist.go
+++ b/page_playlist.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/spezifisch/stmps/logger"
 	"github.com/spezifisch/stmps/subsonic"
+	"github.com/spf13/viper"
 )
 
 type PlaylistPage struct {
@@ -197,7 +198,11 @@ func (p *PlaylistPage) UpdatePlaylists() {
 	}
 	p.isUpdating = true
 
-	var spinnerText []rune = []rune("⠁⠂⠄⡀⢀⠠⠐⠈")
+	var spinnerText []rune = []rune(viper.GetString("ui.spinner"))
+	if len(spinnerText) == 0 {
+		spinnerText = []rune("▉▊▋▌▍▎▏▎▍▌▋▊▉")
+	}
+	spinnerMax := len(spinnerText) - 1
 	playlistsButton := buttonOrder[2]
 	stop := make(chan bool)
 	go func() {
@@ -217,7 +222,7 @@ func (p *PlaylistPage) UpdatePlaylists() {
 					label := fmt.Sprintf(format, 3, spinnerText[idx], playlistsButton)
 					p.ui.menuWidget.buttons[playlistsButton].SetLabel(label)
 					idx++
-					if idx > 7 {
+					if idx > spinnerMax {
 						idx = 0
 					}
 				})


### PR DESCRIPTION
Per [your comment](https://github.com/spezifisch/stmps/pull/32#issuecomment-2346127938) about the spinner being difficult to notice and it being nice if it were configurable, this PR implements that. I guessed that it'd be a 6-line change and that's exactly what it is (if you squint and 1 add + 1 remove = 1 change).

I added some verbiage in the README about this feature, and provide several alternative spinners that can be copy/pasted into a config.

I placed the config in a new section; the option is `ui.spinner`.

I made a design decision to simply reference `viper` directly in `page_playlist.go`, rather than creating a persistent field for it and passing it down through the GUI init branch; I hate adding dependencies like this, but it was either a small, surgical change or a substantial API refactoring changing multiple files, and I went with simple.

I also took the opportunity to change the default spinner to be a more eye-catching one. It looks like this:

![capture](https://github.com/user-attachments/assets/c228ae64-5f2e-4f05-bb9e-c5aee425b13e)

