### PR TITLE
Implements #36: adds ability to reorder the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ These controls are accessible from any view:
 - `d`/`Delete`: Remove currently selected song from the queue
 - `D`: Remove all songs from queue
 - `y`: Toggle star on song
+- `k`: Move song up in queue
+- `j`: Move song down in queue
+
+If the currently playing song is moved, the music is stopped before the move, and must be re-started manually.
 
 ### Playlist Controls
 

--- a/help_text.go
+++ b/help_text.go
@@ -34,6 +34,7 @@ D     remove all songs from queue
 y     toggle star on song
 k     move selected song up in queue
 j     move selected song down in queue
+S     shuffle the current queue
 `
 
 const helpPagePlaylists = `

--- a/help_text.go
+++ b/help_text.go
@@ -32,6 +32,8 @@ const helpPageQueue = `
 d/DEL remove currently selected song from the queue
 D     remove all songs from queue
 y     toggle star on song
+k     move selected song up in queue
+j     move selected song down in queue
 `
 
 const helpPagePlaylists = `

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -283,6 +283,30 @@ func (p *Player) AddToQueue(item *QueueItem) {
 	p.queue = append(p.queue, *item)
 }
 
+func (p *Player) MoveSongUp(index int) {
+	if index < 1 {
+		p.logger.Printf("MoveSongUp(%d) can't move top item", index)
+		return
+	}
+	if index >= len(p.queue) {
+		p.logger.Printf("MoveSongUp(%d) not that many songs in queue", index)
+		return
+	}
+	p.queue[index-1], p.queue[index] = p.queue[index], p.queue[index-1]
+}
+
+func (p *Player) MoveSongDown(index int) {
+	if index < 0 {
+		p.logger.Printf("MoveSongUp(%d) invalid index", index)
+		return
+	}
+	if index >= len(p.queue)-1 {
+		p.logger.Printf("MoveSongUp(%d) can't move last song down", index)
+		return
+	}
+	p.queue[index], p.queue[index+1] = p.queue[index+1], p.queue[index]
+}
+
 func (p *Player) GetQueueItem(index int) (QueueItem, error) {
 	if index < 0 || index >= len(p.queue) {
 		return QueueItem{}, errors.New("invalid queue entry")

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -5,6 +5,7 @@ package mpvplayer
 
 import (
 	"errors"
+	"math/rand"
 	"strconv"
 
 	"github.com/spezifisch/stmps/logger"
@@ -305,6 +306,15 @@ func (p *Player) MoveSongDown(index int) {
 		return
 	}
 	p.queue[index], p.queue[index+1] = p.queue[index+1], p.queue[index]
+}
+
+func (p *Player) Shuffle() {
+	max := len(p.queue)
+	for range max / 2 {
+		ra := rand.Intn(max)
+		rb := rand.Intn(max)
+		p.queue[ra], p.queue[rb] = p.queue[rb], p.queue[ra]
+	}
 }
 
 func (p *Player) GetQueueItem(index int) (QueueItem, error) {

--- a/page_queue.go
+++ b/page_queue.go
@@ -57,22 +57,22 @@ func (ui *Ui) createQueuePage() *QueuePage {
 	queuePage.queueList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyDelete || event.Rune() == 'd' {
 			queuePage.handleDeleteFromQueue()
-			return nil
 		} else {
 			switch event.Rune() {
 			case 'y':
 				queuePage.handleToggleStar()
-				return nil
 			case 'j':
 				queuePage.moveSongDown()
-				return nil
 			case 'k':
 				queuePage.moveSongUp()
-				return nil
+			case 'S':
+				queuePage.shuffle()
+			default:
+				return event
 			}
 		}
 
-		return event
+		return nil
 	})
 
 	// flex wrapper
@@ -215,6 +215,18 @@ func (q *QueuePage) moveSongDown() {
 	// remove the item from the queue
 	q.ui.player.MoveSongDown(currentIndex)
 	q.queueList.Select(currentIndex+1, column)
+	q.updateQueue()
+}
+
+func (q *QueuePage) shuffle() {
+	if len(q.queueData.playerQueue) == 0 {
+		return
+	}
+
+	q.ui.player.Stop()
+	q.ui.player.Shuffle()
+
+	q.queueList.Select(0, 0)
 	q.updateQueue()
 }
 


### PR DESCRIPTION
This adds the ability for the user to re-arrange items in the queue.

1. If the music is playing and the top item changes (it's either moved down, or the one below is moved up), the music is stopped before the move. The music is not automatically restarted. This was to prevent jittering while re-arranging.
2. Moving the top item up, or the bottom item down, is a NOP: it doesn't stop the music or change anything. It does, however, log a non-error message.
3. The Queue help text and README have been updated.
4. Bounds are checked in both the queue and the player struct methods; belts and suspenders.

If we think of better hotkeys, it's easy enough to can change them. They mirror vim at the moment. 

P.S. I added a queue shuffle function under the `S` key, b/c it was easy and I mentioned it in the request ticket.