### PR TITLE
Makes 'a' in the browser tab consistent

### DIFF
--- a/page_browser.go
+++ b/page_browser.go
@@ -267,6 +267,10 @@ func (b *BrowserPage) handleAddArtistToQueue() {
 		}
 	}
 
+	if currentIndex+1 < b.artistList.GetItemCount() {
+		b.artistList.SetCurrentItem(currentIndex + 1)
+	}
+
 	b.ui.queuePage.UpdateQueue()
 }
 


### PR DESCRIPTION
`a` in the entities column (albums or songs) advances the selection cursor to the next item. This tiny patch makes the action in the artists column behave the same way so the UX is consistent. Consistency is sufficient, IMO, but if for no other reason, it also provides feedback to the user that their button press did something.