### PR TITLE
Issue #38: addresses linting errors introduced by recent code changes.

### DIFF
--- a/page_queue.go
+++ b/page_queue.go
@@ -179,7 +179,8 @@ func (q *QueuePage) moveSongUp() {
 	}
 
 	if currentIndex == 1 {
-		q.ui.player.Stop()
+		// An error here won't affect re-arranging the queue.
+		_ = q.ui.player.Stop()
 	}
 
 	// remove the item from the queue
@@ -204,7 +205,8 @@ func (q *QueuePage) moveSongDown() {
 	}
 
 	if currentIndex == 0 {
-		q.ui.player.Stop()
+		// An error here won't affect re-arranging the queue.
+		_ = q.ui.player.Stop()
 	}
 
 	if currentIndex > queueLen-2 {
@@ -223,7 +225,8 @@ func (q *QueuePage) shuffle() {
 		return
 	}
 
-	q.ui.player.Stop()
+	// An error here won't affect re-arranging the queue.
+	_ = q.ui.player.Stop()
 	q.ui.player.Shuffle()
 
 	q.queueList.Select(0, 0)

--- a/page_search.go
+++ b/page_search.go
@@ -251,6 +251,10 @@ func (s *SearchPage) addArtistToQueue(entity subsonic.Ider) {
 
 	for _, album := range response.Artist.Album {
 		response, err = s.ui.connection.GetAlbum(album.Id)
+		if err != nil {
+			s.logger.PrintError("addArtistToQueue unable to get album artist from server", err)
+			return
+		}
 		sort.Sort(response.Album.Song)
 		for _, e := range response.Album.Song {
 			for _, art := range e.Artists {


### PR DESCRIPTION
Just the recently added ones -- I did not do a full spectrum linting check, just the one run in the workflow.

In one case, the ignoring the error was the wrong thing to do; in the other, any error would not prevent the (client-side) queue changes, so they're ignored.