### PR TITLE
Album search results from Navidrome were not being added to the album column

### DIFF
--- a/page_search.go
+++ b/page_search.go
@@ -228,7 +228,7 @@ func (s *SearchPage) search() {
 		s.artists = append(s.artists, &artist)
 	}
 	for _, album := range res.SearchResults.Album {
-		s.albumList.AddItem(tview.Escape(album.Album), "", 0, nil)
+		s.albumList.AddItem(tview.Escape(album.Name), "", 0, nil)
 		s.albums = append(s.albums, &album)
 	}
 	for _, song := range res.SearchResults.Song {
@@ -247,14 +247,26 @@ func (s *SearchPage) addArtistToQueue(entity subsonic.Ider) {
 		s.logger.Printf("addArtistToQueue: GetArtist %s -- %s", entity.ID(), err.Error())
 		return
 	}
-	artistName := response.Artist.Name
 
+	artistId := response.Artist.Id
 	for _, album := range response.Artist.Album {
 		response, err = s.ui.connection.GetAlbum(album.Id)
 		sort.Sort(response.Album.Song)
+		// We make sure we add only albums who's artists match the artist
+		// being added; this prevents collection albums with many different
+		// artists that show up in the Album column having _all_ of the songs
+		// on the album -- even ones that don't match the artist -- from
+		// being added when the user adds an album from the search results.
 		for _, e := range response.Album.Song {
+			// Depending on the server implementation, the server may or may not
+			// respond with a list of artists. If either the Artist field matches,
+			// or the artist name is in a list of artists, then we add the song.
+			if e.ArtistId == artistId {
+				s.ui.addSongToQueue(&e)
+				continue
+			}
 			for _, art := range e.Artists {
-				if art.Name == artistName {
+				if art.Id == artistId {
 					s.ui.addSongToQueue(&e)
 					break
 				}

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -139,7 +139,7 @@ type Album struct {
 	Genres        []Genre          `json:"genres"`
 	Year          int              `json:"year"`
 	Song          SubsonicEntities `json:"song"`
-	CoverArt      string           `json"coverArt"`
+	CoverArt      string           `json:"coverArt"`
 }
 
 func (s Album) ID() string {

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -33,7 +33,7 @@ type SubsonicConnection struct {
 func Init(logger logger.LoggerInterface) *SubsonicConnection {
 	return &SubsonicConnection{
 		clientName:    "example",
-		clientVersion: "1.0.0",
+		clientVersion: "1.8.0",
 
 		logger:         logger,
 		directoryCache: make(map[string]SubsonicResponse),
@@ -125,6 +125,7 @@ func (s Artist) ID() string {
 type Album struct {
 	Id            string           `json:"id"`
 	Created       string           `json:"created"`
+	ArtistId      string           `json:"artistId"`
 	Artist        string           `json:"artist"`
 	Artists       []Artist         `json:"artists"`
 	DisplayArtist string           `json:"displayArtist"`
@@ -138,6 +139,7 @@ type Album struct {
 	Genres        []Genre          `json:"genres"`
 	Year          int              `json:"year"`
 	Song          SubsonicEntities `json:"song"`
+	CoverArt      string           `json"coverArt"`
 }
 
 func (s Album) ID() string {
@@ -153,6 +155,7 @@ type SubsonicEntity struct {
 	IsDirectory bool     `json:"isDir"`
 	Parent      string   `json:"parent"`
 	Title       string   `json:"title"`
+	ArtistId    string   `json:"artistId"`
 	Artist      string   `json:"artist"`
 	Artists     []Artist `json:"artists"`
 	Duration    int      `json:"duration"`


### PR DESCRIPTION
c.f. https://github.com/spezifisch/stmps/pull/40\#issuecomment-2361716375

The Subsonic API definition is sufficiently vague as to leave some implementation details to the servers, and Gonic and Navidrome implement search3 results slightly differently. What was causing the Navidrome issue is that Gonic includes the album name under both a `Album` and `Name` attributes, whereas Navidrome only provides the `Name` attribute. My code was, of course, matching on the (for Navidrome) empty `Album` attribute. Since Gonic provides both attributes, this patch compares the `Name` attribute in all instances.

This patch includes a couple of other related changes:

First, since `search3` was introduced in the Subsonic API version `1.8.0`, and Subsonic API servers require this version (although I expect most ignore it), I updated the `SubsonicConnection.clientVersion` from 1.0.0 to 1.8.0.

Second, the responses that include an artist always include an `artistId` attribute. Previously, the search code was comparing the `artistName`, not the `artistId`. We can debate which is more correct: it's conceivably possible for a server to have an artist under two different IDs, but matching by ID seems more correct, so this has been changed. I suspect more of this sort of change is scattered through the code, but I caught one place here.

Completely unrelated, `SubsonicEntity`s often include a cover art ID, which was not captured. I have a vague itch to someday use something like [timg](https://github.com/codeliveroil/img) to show the cover art, maybe as part of the #25 "song info" ticket. I was in the struct making changes, and I snuck this in.