### PR TITLE
Implements #25, display song info.

### DIFF
--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -165,6 +165,7 @@ func (ui *Ui) addSongToQueue(entity *subsonic.SubsonicEntity) {
 		Duration:    entity.Duration,
 		Album:       album,
 		TrackNumber: entity.Track,
+		DiscNumber:  entity.DiscNumber,
 	}
 	ui.player.AddToQueue(queueItem)
 }
@@ -178,6 +179,7 @@ func makeSongHandler(entity *subsonic.SubsonicEntity, ui *Ui, fallbackArtist str
 	artist := stringOr(entity.Artist, fallbackArtist)
 	duration := entity.Duration
 	track := entity.Track
+	disc := entity.DiscNumber
 
 	response, err := ui.connection.GetAlbum(entity.Parent)
 	album := ""
@@ -195,7 +197,7 @@ func makeSongHandler(entity *subsonic.SubsonicEntity, ui *Ui, fallbackArtist str
 	}
 
 	return func() {
-		if err := ui.player.PlayUri(id, uri, title, artist, album, duration, track); err != nil {
+		if err := ui.player.PlayUri(id, uri, title, artist, album, duration, track, disc); err != nil {
 			ui.logger.PrintError("SongHandler Play", err)
 			return
 		}

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -125,8 +125,8 @@ func (p *Player) PlayNextTrack() error {
 	return nil
 }
 
-func (p *Player) PlayUri(id string, uri string, title string, artist string, duration int) error {
-	p.queue = []QueueItem{{id, uri, title, artist, duration}}
+func (p *Player) PlayUri(id, uri, title, artist, album string, duration, track int) error {
+	p.queue = []QueueItem{{id, uri, title, artist, duration, album, track}}
 	p.replaceInProgress = true
 	if ip, e := p.IsPaused(); ip && e == nil {
 		if err := p.Pause(); err != nil {

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -125,8 +125,8 @@ func (p *Player) PlayNextTrack() error {
 	return nil
 }
 
-func (p *Player) PlayUri(id, uri, title, artist, album string, duration, track int) error {
-	p.queue = []QueueItem{{id, uri, title, artist, duration, album, track}}
+func (p *Player) PlayUri(id, uri, title, artist, album string, duration, track, disc int) error {
+	p.queue = []QueueItem{{id, uri, title, artist, duration, album, track, disc}}
 	p.replaceInProgress = true
 	if ip, e := p.IsPaused(); ip && e == nil {
 		if err := p.Pause(); err != nil {

--- a/mpvplayer/queue_item.go
+++ b/mpvplayer/queue_item.go
@@ -6,11 +6,13 @@ package mpvplayer
 import "github.com/spezifisch/stmps/remote"
 
 type QueueItem struct {
-	Id       string
-	Uri      string
-	Title    string
-	Artist   string
-	Duration int
+	Id          string
+	Uri         string
+	Title       string
+	Artist      string
+	Duration    int
+	Album       string
+	TrackNumber int
 }
 
 var _ remote.TrackInterface = (*QueueItem)(nil)
@@ -44,9 +46,9 @@ func (q QueueItem) GetUri() string {
 }
 
 func (q QueueItem) GetAlbum() string {
-	return ""
+	return q.Album
 }
 
 func (q QueueItem) GetTrackNumber() int {
-	return 0
+	return q.TrackNumber
 }

--- a/mpvplayer/queue_item.go
+++ b/mpvplayer/queue_item.go
@@ -13,6 +13,7 @@ type QueueItem struct {
 	Duration    int
 	Album       string
 	TrackNumber int
+	DiscNumber  int
 }
 
 var _ remote.TrackInterface = (*QueueItem)(nil)
@@ -51,4 +52,8 @@ func (q QueueItem) GetAlbum() string {
 
 func (q QueueItem) GetTrackNumber() int {
 	return q.TrackNumber
+}
+
+func (q QueueItem) GetDiscNumber() int {
+	return q.DiscNumber
 }

--- a/page_queue.go
+++ b/page_queue.go
@@ -327,5 +327,6 @@ func (q *queueData) GetColumnCount() int {
 var songInfoTemplateString = `[blue::b]Title:[-:-:-:-] [green::i]{{.Title}}[-:-:-:-]
 [blue::b]Artist:[-:-:-:-] [::i]{{.Artist}}[-:-:-:-]
 [blue::b]Album:[-:-:-:-] [::i]{{.GetAlbum}}[-:-:-:-]
+[blue::b]Disc:[-:-:-:-] [::i]{{.GetDiscNumber}}[-:-:-:-]
 [blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]
 [blue::b]Duration:[-:-:-:-] [::i]{{formatTime .Duration}}[-:-:-:-] `

--- a/page_queue.go
+++ b/page_queue.go
@@ -49,7 +49,7 @@ type QueuePage struct {
 func (ui *Ui) createQueuePage() *QueuePage {
 	tmpl := template.New("song info").Funcs(template.FuncMap{
 		"formatTime": func(i int) string {
-			return fmt.Sprintf("%s", time.Duration(i)*time.Second)
+			return (time.Duration(i) * time.Second).String()
 		},
 	})
 	songInfoTemplate, err := tmpl.Parse(songInfoTemplateString)

--- a/page_queue.go
+++ b/page_queue.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"text/template"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -35,15 +36,24 @@ type QueuePage struct {
 	queueList *tview.Table
 	queueData queueData
 
+	songInfo *tview.TextView
+
 	// external refs
 	ui     *Ui
 	logger logger.LoggerInterface
+
+	songInfoTemplate *template.Template
 }
 
 func (ui *Ui) createQueuePage() *QueuePage {
+	songInfoTemplate, err := template.New("song info").Parse(songInfoTemplateString)
+	if err != nil {
+		ui.logger.PrintError("createQueuePage", err)
+	}
 	queuePage := QueuePage{
-		ui:     ui,
-		logger: ui.logger,
+		ui:               ui,
+		logger:           ui.logger,
+		songInfoTemplate: songInfoTemplate,
 	}
 
 	// main table
@@ -75,9 +85,16 @@ func (ui *Ui) createQueuePage() *QueuePage {
 		return nil
 	})
 
+	// Song info
+	queuePage.songInfo = tview.NewTextView()
+	queuePage.songInfo.SetDynamicColors(true).SetScrollable(true).SetBorder(true).SetTitle("Song Info")
+
+	queuePage.queueList.SetSelectionChangedFunc(queuePage.changeSelection)
+
 	// flex wrapper
-	queuePage.Root = tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(queuePage.queueList, 0, 1, true)
+	queuePage.Root = tview.NewFlex().SetDirection(tview.FlexColumn).
+		AddItem(queuePage.queueList, 0, 2, true).
+		AddItem(queuePage.songInfo, 0, 1, false)
 
 	// private data
 	queuePage.queueData = queueData{
@@ -85,6 +102,15 @@ func (ui *Ui) createQueuePage() *QueuePage {
 	}
 
 	return &queuePage
+}
+
+func (q *QueuePage) changeSelection(row, column int) {
+	q.songInfo.Clear()
+	if row >= len(q.queueData.playerQueue) || row < 0 || column < 0 {
+		return
+	}
+	currentSong := q.queueData.playerQueue[row]
+	_ = q.songInfoTemplate.Execute(q.songInfo, currentSong)
 }
 
 func (q *QueuePage) UpdateQueue() {
@@ -158,6 +184,9 @@ func (q *QueuePage) updateQueue() {
 	if queueWasEmpty {
 		q.queueList.ScrollToBeginning()
 	}
+
+	r, c := q.queueList.GetSelection()
+	q.changeSelection(r, c)
 }
 
 // moveSongUp moves the currently selected song up in the queue
@@ -288,3 +317,8 @@ func (q *queueData) GetRowCount() int {
 func (q *queueData) GetColumnCount() int {
 	return queueDataColumns
 }
+
+var songInfoTemplateString = `[blue::b]Title:[-:-:-:-] [green::i]{{.Title}}[-:-:-:-]
+[blue::b]Artist:[-:-:-:-] [::i]{{.Artist}}[-:-:-:-]
+[blue::b]Album:[-:-:-:-] [::i]{{.GetAlbum}}[-:-:-:-]
+[blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]`

--- a/page_queue.go
+++ b/page_queue.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -46,7 +47,12 @@ type QueuePage struct {
 }
 
 func (ui *Ui) createQueuePage() *QueuePage {
-	songInfoTemplate, err := template.New("song info").Parse(songInfoTemplateString)
+	tmpl := template.New("song info").Funcs(template.FuncMap{
+		"formatTime": func(i int) string {
+			return fmt.Sprintf("%s", time.Duration(i)*time.Second)
+		},
+	})
+	songInfoTemplate, err := tmpl.Parse(songInfoTemplateString)
 	if err != nil {
 		ui.logger.PrintError("createQueuePage", err)
 	}
@@ -321,4 +327,5 @@ func (q *queueData) GetColumnCount() int {
 var songInfoTemplateString = `[blue::b]Title:[-:-:-:-] [green::i]{{.Title}}[-:-:-:-]
 [blue::b]Artist:[-:-:-:-] [::i]{{.Artist}}[-:-:-:-]
 [blue::b]Album:[-:-:-:-] [::i]{{.GetAlbum}}[-:-:-:-]
-[blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]`
+[blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]
+[blue::b]Duration:[-:-:-:-] [::i]{{formatTime .Duration}}[-:-:-:-] `

--- a/remote/interfaces.go
+++ b/remote/interfaces.go
@@ -43,6 +43,7 @@ type TrackInterface interface {
 	GetAlbumArtist() string
 	GetAlbum() string
 	GetTrackNumber() int
+	GetDiscNumber() int
 
 	// something like ID != ""
 	IsValid() bool

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -157,7 +157,7 @@ type SubsonicEntity struct {
 	Artists     []Artist `json:"artists"`
 	Duration    int      `json:"duration"`
 	Track       int      `json:"track"`
-	DiskNumber  int      `json:"diskNumber"`
+	DiscNumber  int      `json:"discNumber"`
 	Path        string   `json:"path"`
 }
 

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -301,7 +301,10 @@ func (connection *SubsonicConnection) GetArtist(id string) (*SubsonicResponse, e
 
 func (connection *SubsonicConnection) GetAlbum(id string) (*SubsonicResponse, error) {
 	if cachedResponse, present := connection.directoryCache[id]; present {
-		return &cachedResponse, nil
+		// This is because Albums that were fetched as Directories aren't populated correctly
+		if cachedResponse.Album.Name != "" {
+			return &cachedResponse, nil
+		}
 	}
 
 	query := defaultQuery(connection)


### PR DESCRIPTION
This is implemented as a side-bar column in the play queue:

![capture](https://github.com/user-attachments/assets/23aee9ff-4bc6-430f-90d9-15251dabd169)

Upsides:

1. You'll notice that when the song title is really long, this format can help, as otherwise most of the information (artist, duration) gets pushed off the screen by the title. Users can scroll right, of course, but this keeps all of the song info visible at once.
2. There's space to display the cover art. And I really want to display the cover art; Subsonic's API provides it, and there are several Go applications that raster images to terminals that can be worked from. In any case, this approach leaves that option open.
3. There's more space for displaying other metadata (CD number, release year, genre, etc.)
4. These sorts of changes to the metadata column are _relatively_ easy, because the contents are formatted by a `text/template` (at the end of `page_queue.go`). If it weren't for the fact that the Song entity is pretty anemic and doesn't capture all of the information the server provides, adding more data would be a mere matter of adding lines to the template. It'd be really easy to capture this extra metadata, but I wanted to keep this PR relatively constrained.

The downside is that it takes up space.

I also considered just adding more columns to the queue; namely, the Album and Track.  The pro of doing this is that it keeps the UI clean; the downside is that there's only so much information you can squish into that table without forcing the user to scroll around to see things.

I briefly considered implementing both and allowing the user to choose which with a flag, but that seems better left to a different PR.

It might be useful to add a hotkey to allow the user to hide the metadata column; I understand how to hide pages in `tview`, but figuring out how to hide elements would -- while not necessarily hard -- have required significantly more time on my end in self-education.

I'm sending this as you've included this item in [milestone #1](https://github.com/spezifisch/stmps/milestone/1). I'm going to add a ticket to capture more of the song metadata the servers are providing and add them to the template; another one for displaying cover art; and another for hotkey hiding/showing the metadata column.