### PR TITLE
Adds ticket #11, sort by dis[c]number

### DIFF
--- a/page_browser.go
+++ b/page_browser.go
@@ -258,6 +258,8 @@ func (b *BrowserPage) handleAddArtistToQueue() {
 		return
 	}
 
+	sort.Sort(b.currentDirectory.Entities)
+
 	for _, entity := range b.currentDirectory.Entities {
 		if entity.IsDirectory {
 			b.addDirectoryToQueue(&entity)

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -207,13 +207,11 @@ func (s SubsonicEntities) Less(i, j int) bool {
 	// Disk and track numbers are only relevant within the same parent
 	if s[i].Parent == s[j].Parent {
 		// sort first by DiskNumber
-		if s[i].DiscNumber < s[j].DiscNumber {
-			return true
-		} else if s[i].DiscNumber > s[j].DiscNumber {
-			return false
+		if s[i].DiscNumber == s[j].DiscNumber {
+			// Tracks on the same disk are sorted by track
+			return s[i].Track < s[j].Track
 		}
-		// Tracks on the same disk are sorted by track
-		return s[i].Track < s[j].Track
+		return s[i].DiscNumber < s[j].DiscNumber
 	}
 	// If we get here, the songs are either from different albums, or else
 	// they're on the same disk


### PR DESCRIPTION
This implements ordering by discNumber.

The tag field _must_ be dis**c**Number, as neither gonic nor Navidrome will pick up the tag if it's spelled dis**k**number.

The sorting algorithm has been changed to ensure that DISCNUMBER and TRACKNUMBER are _only_ used within the same albums; it's possible (although, unlikely) that TRACKNUMBER could have crossed albums.

Sorting is now:
1. DISCNUMBER
2. TRACKNUMBER
3. TITLE

and TITLE only if the entities don't share a parent.

This completes another ticket for [milestone v1.0.0](https://github.com/spezifisch/stmps/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.0.0).