### PR TITLE
Adds feature 54: save queue on exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ These controls are accessible from any view:
 - `j`: Move song down in queue
 - `s`: Save the queue as a playlist
 - `S`: Shuffle the songs in the queue
+- `l`: Load a queue previously saved to the server
+
+When stmps exits, the queue is automatically recorded to the server, including the position in the song being played. There is a *single* queue per user that can be thusly saved. Because empty queues can not be stored on Subsonic servers, this queue is not automatically loaded; the `l` binding on the queue page will load the previous queue and seek to the last position in the top song.
 
 If the currently playing song is moved, the music is stopped before the move, and must be re-started manually.
 

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/spezifisch/stmps/mpvplayer"
 	"github.com/spezifisch/stmps/subsonic"
@@ -117,7 +119,21 @@ func (ui *Ui) ShowPage(name string) {
 }
 
 func (ui *Ui) Quit() {
-	// TODO savePlayQueue/getPlayQueue
+	if len(ui.queuePage.queueData.playerQueue) > 0 {
+		ids := make([]string, len(ui.queuePage.queueData.playerQueue))
+		for i, it := range ui.queuePage.queueData.playerQueue {
+			ids[i] = it.Id
+		}
+		// stmps always only ever plays the first song in the queue
+		pos := ui.player.GetTimePos()
+		if err := ui.connection.SavePlayQueue(ids, ids[0], int(pos)); err != nil {
+			log.Printf("error stashing play queue: %s", err)
+		}
+	} else {
+		// The only way to purge a saved play queue is to force an error by providing
+		// bad data. Therefore, we ignore errors.
+		_ = ui.connection.SavePlayQueue([]string{"XXX"}, "XXX", 0)
+	}
 	ui.player.Quit()
 	ui.app.Stop()
 }

--- a/help_text.go
+++ b/help_text.go
@@ -37,6 +37,7 @@ k     move selected song up in queue
 j     move selected song down in queue
 s     save queue as a playlist
 S     shuffle the current queue
+l     load last queue from server
 `
 
 const helpPagePlaylists = `

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -376,8 +376,8 @@ func (p *Player) IsSeeking() (bool, error) {
 	return false, nil
 }
 
-func (p *Player) SeekAbsolute(float64) error {
-	return nil
+func (p *Player) SeekAbsolute(position int) error {
+	return p.instance.Command([]string{"seek", strconv.Itoa(position), "absolute"})
 }
 
 func (p *Player) Play() error {

--- a/page_playlist.go
+++ b/page_playlist.go
@@ -248,6 +248,11 @@ func (p *PlaylistPage) UpdatePlaylists() {
 		if err != nil {
 			p.logger.PrintError("GetPlaylists", err)
 		}
+		if response == nil {
+			p.logger.Printf("no error from GetPlaylists, but also no response!")
+			stop <- true
+			return
+		}
 		p.updatingMutex.Lock()
 		defer p.updatingMutex.Unlock()
 		p.ui.playlists = response.Playlists.Playlists

--- a/remote/interfaces.go
+++ b/remote/interfaces.go
@@ -28,7 +28,7 @@ type ControlledPlayer interface {
 	Play() error
 	Pause() error
 	Stop() error
-	SeekAbsolute(float64) error
+	SeekAbsolute(int) error
 	NextTrack() error
 	PreviousTrack() error
 

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -125,6 +125,12 @@ type ScanStatus struct {
 	Count    int  `json:"count"`
 }
 
+type PlayQueue struct {
+	Current  string           `json:"current"`
+	Position int              `json:"position"`
+	Entries  SubsonicEntities `json:"entry"`
+}
+
 type Artist struct {
 	Id         string  `json:"id"`
 	Name       string  `json:"name"`
@@ -271,6 +277,7 @@ type SubsonicResponse struct {
 	Album         Album             `json:"album"`
 	SearchResults SubsonicResults   `json:"searchResult3"`
 	ScanStatus    ScanStatus        `json:"scanStatus"`
+	PlayQueue     PlayQueue         `json:"playQueue"`
 }
 
 type responseWrapper struct {
@@ -662,4 +669,22 @@ func (connection *SubsonicConnection) StartScan() error {
 		return fmt.Errorf("server returned false for scan status on scan attempt")
 	}
 	return nil
+}
+
+func (connection *SubsonicConnection) SavePlayQueue(queueIds []string, current string, position int) error {
+	query := defaultQuery(connection)
+	for _, songId := range queueIds {
+		query.Add("id", songId)
+	}
+	query.Set("current", current)
+	query.Set("position", fmt.Sprintf("%d", position))
+	requestUrl := fmt.Sprintf("%s/rest/savePlayQueue?%s", connection.Host, query.Encode())
+	_, err := connection.getResponse("SavePlayQueue", requestUrl)
+	return err
+}
+
+func (connection *SubsonicConnection) LoadPlayQueue() (*SubsonicResponse, error) {
+	query := defaultQuery(connection)
+	requestUrl := fmt.Sprintf("%s/rest/getPlayQueue?%s", connection.Host, query.Encode())
+	return connection.getResponse("GetPlayQueue", requestUrl)
 }


### PR DESCRIPTION
Saving works fine; loading works, but seeking to the last saved point is broken, and I can't figure it out. I'm conflicted about this PR. Either we keep it, or just close #54 as "won't fix".

So, the idea is good, and the API supports it: a single ephemeral queue per user that can be saved and loaded. The idea behind the original endpoint was to allow users to switch between clients without losing their queue. It's not permanent or named, like a playlist. It also saves the timestamp in the last song you were playing, so you could (e.g.) quit your stmps client, get in your car, and start up Ultrasonic on your phone and keep on truckin'. I implemented it so that loading is in the background and doesn't affect the UI.

My original idea was simple: save the queue on exit, load it on start. However, there are a couple of issues: 

First, there's [no way to delete or clear it once it's saved on the server](https://github.com/opensubsonic/open-subsonic-api/discussions/105). There's no `deletePlayQueue`, and the list parameters are mandatory for the `savePlayQueue`. This is a problem with stmps because -- as you know -- the queue is _consumed_ as it's played. So, if you save a queue, but then play all the songs and exit, the next time you start stmps you'll get that old queue you saved. A bit annoying. My work-around was to go ahead and save the queue state on exit, but require the user to manually load the saved queue if they want it: `l` on the queue page.

Second, I can _not_ get `seek` to work. I know I'm getting the value, and I know it's the right unit of measure (seconds), but I get a cryptic `mpv error -12` and no other information. I wasted a bunch of time digging around in `go-mpv` and the `mpv` project, but can't figure out why it isn't working. 

Third, the upstream feature itself has some complaints about (a) poorly defined server behavior, and (b) just bad API design. Like, if the queue is big enough, the call fails because they defined it as a GET rather than a POST (or PUSH) with a body, and you can overload the URI with too many `id` parameters. 

The last issue doesn't bother me so much, but the other two put a real damper on my enthusiasm for this feature.  I suppose it's still useful, and I'd like to figure out the seek issue, but I've hit a wall and don't want to waste more time on it.

So, really, it's your call whether to merge this or not. I won't be offended if you don't.