### PR TITLE
Add improved documentation about search page; Changes search page foc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The default is `▉▊▋▌▍▎▏▎▍▌▋▊▉`. Set only one of these 
 
 ### Search Controls
 
-The search tab performs a server-side search for text in metadata name fields.
+The search page performs a server-side search for text in IDv3 metadata fields.
 The search results are filtered into three columns: artist, album, and song. 20
 results (in each column) are fetched at a time; use `n` to load more results.
 
@@ -162,6 +162,8 @@ In the search field:
 
 - `Enter`: Perform the query.
 - `Escape`: Escapes into the columns, where the global key bindings work.
+
+Note that the Search page is *not* a browser like the Browser page: it displays the search results returned by the server. Selecting a different artist will not change the album or song search results. OpenSubsonic servers implement the search function differently; in gonic, if you search for "black", you will get artists with "black" in their names in the artists column; albums with "black" in their titles in the albums column; and songs with "black" in their titles in the songs column. Navidrome appears to include all results with "black" anywhere in their IDv3 metadata. Since the API search results filteres these matches into sections -- artists, albums, and songs -- this means that, with Navidrome, you may see albums that don't have "black" in their names; maybe "black" is in their artist title.
 
 ## Advanced Configuration and Features
 

--- a/help_text.go
+++ b/help_text.go
@@ -46,14 +46,18 @@ a     add playlist or song to queue
 `
 
 const helpSearchPage = `
-artist, album, or song tab
-  Down    focus search field
+artist, album, or song column
+  Down/Up navigate within the column
   Left    previous column
   Right   next column
-  Enter   recursively add item to quue
-  a       recursively add item to quue
-  /       start search
+  Enter/a recursively add item to quue
+  /       start search (20 results per)
   n       load more results
+
 search field
   Enter   search for text
+  Esc     cancel search
+
+Note: unlike browser, columns navigate
+ search results, not selected items.
 `

--- a/page_playlist.go
+++ b/page_playlist.go
@@ -247,6 +247,9 @@ func (p *PlaylistPage) UpdatePlaylists() {
 		response, err := p.ui.connection.GetPlaylists()
 		if err != nil {
 			p.logger.PrintError("GetPlaylists", err)
+			p.isUpdating = false
+			stop <- true
+			return
 		}
 		p.updatingMutex.Lock()
 		defer p.updatingMutex.Unlock()

--- a/page_search.go
+++ b/page_search.go
@@ -69,16 +69,19 @@ func (ui *Ui) createSearchPage() *SearchPage {
 	// search bar
 	searchPage.searchField = tview.NewInputField().
 		SetLabel("search:").
-		SetFieldBackgroundColor(tcell.ColorBlack)
+		SetFieldBackgroundColor(tcell.ColorBlack).
+		SetDoneFunc(func(key tcell.Key) {
+			searchPage.aproposFocus()
+		})
 
 	searchPage.columnsFlex = tview.NewFlex().SetDirection(tview.FlexColumn).
-		AddItem(searchPage.artistList, 0, 1, false).
+		AddItem(searchPage.artistList, 0, 1, true).
 		AddItem(searchPage.albumList, 0, 1, false).
 		AddItem(searchPage.songList, 0, 1, false)
 
 	searchPage.Root = tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(searchPage.columnsFlex, 0, 1, false).
-		AddItem(searchPage.searchField, 1, 1, true)
+		AddItem(searchPage.columnsFlex, 0, 1, true).
+		AddItem(searchPage.searchField, 1, 1, false)
 
 	searchPage.artistList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
@@ -174,15 +177,7 @@ func (ui *Ui) createSearchPage() *SearchPage {
 	searchPage.searchField.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
 		case tcell.KeyUp, tcell.KeyESC:
-			if len(searchPage.artists) != 0 {
-				ui.app.SetFocus(searchPage.artistList)
-			} else if len(searchPage.albums) != 0 {
-				ui.app.SetFocus(searchPage.albumList)
-			} else if len(searchPage.songs) != 0 {
-				ui.app.SetFocus(searchPage.songList)
-			} else {
-				ui.app.SetFocus(searchPage.artistList)
-			}
+			searchPage.aproposFocus()
 		case tcell.KeyEnter:
 			searchPage.artistList.Clear()
 			searchPage.artists = make([]*subsonic.Artist, 0)
@@ -195,13 +190,7 @@ func (ui *Ui) createSearchPage() *SearchPage {
 			searchPage.albumOffset = 0
 			searchPage.songOffset = 0
 			searchPage.search()
-			if len(searchPage.artists) > 0 {
-				ui.app.SetFocus(searchPage.artistList)
-			} else if len(searchPage.albums) > 0 {
-				ui.app.SetFocus(searchPage.albumList)
-			} else if len(searchPage.songs) > 0 {
-				ui.app.SetFocus(searchPage.songList)
-			}
+			searchPage.aproposFocus()
 		default:
 			return event
 		}
@@ -292,4 +281,16 @@ func (s *SearchPage) addAlbumToQueue(entity subsonic.Ider) {
 		s.ui.addSongToQueue(&e)
 	}
 	s.ui.queuePage.UpdateQueue()
+}
+
+func (s *SearchPage) aproposFocus() {
+	if len(s.artists) != 0 {
+		s.ui.app.SetFocus(s.artistList)
+	} else if len(s.albums) != 0 {
+		s.ui.app.SetFocus(s.albumList)
+	} else if len(s.songs) != 0 {
+		s.ui.app.SetFocus(s.songList)
+	} else {
+		s.ui.app.SetFocus(s.artistList)
+	}
 }


### PR DESCRIPTION
Per the conversation on [Discussion #28](https://github.com/spezifisch/stmps/discussions/28#discussioncomment-10923239), the focus behavior was inconsistent with the search feature on the `BrowserPage`, and frankly confusing. This PR changes several things:

- It changes the focus policy. The search field now is _never_ auto-focused; instead, it must always be triggered with a `/`, like the search field on the browser page. `/` is now also the _only_ way to navigate to the search field.
- It improves the README documentation and explains how the search page works; in particular, that the search page displays search results, and is not an artist/album navigator.
- It fixes the help text, which was incorrect (did not match actual behavior) and adds an additional blurb about what the search page is doing
- It includes some code refactoring: a 8 identical lines of logic were pulled out of three locations into a function `aproposFocus()`, collapsing 24 lines down to 10.

There is a bug fix in here that will conflict with one of the other PRs. Errors from calls to `getPlaylists()` were not being handled correctly, leading to panics if errors were encountered. In one other PR, I address this by checking for nil responses, but this code is more correct: if we encounter an error, we clean up and return immediately, rather than falling through. This is the single change to `page_playlist.go`, and could be cherry-picked out of this PR.  Whether or not there's a conflict, `PlaylistsPage.UpdatePlaylists()` should use this code and remove the response nil pointer check.