### PR TITLE
fix: #33 selected entry gets stuck

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -106,6 +106,9 @@ func InitGui(indexes *[]subsonic.SubsonicIndex,
 		SetTextAlign(tview.AlignLeft).
 		SetDynamicColors(true).
 		SetScrollable(false)
+	ui.startStopStatus.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		return action, nil
+	})
 
 	statusRight := formatPlayerStatus(0, 0, 0)
 	ui.playerStatus = tview.NewTextView().SetText(statusRight).

--- a/page_queue.go
+++ b/page_queue.go
@@ -121,6 +121,9 @@ func (ui *Ui) createQueuePage() *QueuePage {
 	// Song info
 	queuePage.songInfo = tview.NewTextView()
 	queuePage.songInfo.SetDynamicColors(true).SetScrollable(true)
+	queuePage.songInfo.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		return action, nil
+	})
 
 	queuePage.queueList.SetSelectionChangedFunc(queuePage.changeSelection)
 


### PR DESCRIPTION
This fixes #33 by telling the widget to not handle mouse clicks. The same change was made to the songinfo widget, as it had the same problem.

While testing this, I encountered a couple of other edge cases which should probably also be eventually addressed, but which can't have the same fix:

1. Open the help text. Click on one of the visible background panes. The help text will no longer accept input and can't be dismissed until it is re-selected with the mouse.
2. Click on any of the page selectors on the bottom bar. The clicked page will be shown, but the bottom bar will be selected and the page can't be interacted with until it is re-selected with the mouse.

Neither of these cases can take the simple fix of disabling the mouse, because:

1. In this case, we'd need to dynamically disable the mouse when the help widget is shown for widgets that are _normally_ able to accept mouse clicks; the problem isn't the help modal, the problem is all of the other widgets. This would require extensive, complicated logic to disable _all_ mouse input on _every_ visible widget when the help text is shown, and re-enable them when the help modal is dismissed. Fundamentally, the issue is that tview's _"modal" doesn't really mean modal, and it still lets mouse events past modal dialogs -- which violates the definition of "modal" dialogs.
2. The bar _should_ accept mouse clicks; users should be able to click on a page name to switch to it, so we can't disable mouse clicks on the nav bar. However, it may be possible to prevent it from grabbing focus, and I'm looking into that.

I don't have a good solution for the first issue. It really is an issue with tview, and seems as if it'd be hairy to work around. 