### PR TITLE
Feat 67 hide song panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ random-songs = 50
 spinner = '▁▂▃▄▅▆▇█▇▆▅▄▃▂▁'
 ```
 
+The song info panel on the queue takes up space, and memory for album art. You can disable this panel with:
+
+```toml
+[ui]
+hide-info-panel = true
+```
+
+If the panel is hidden, no album art will be fetched from the server.
+
 ## Usage
 
 ### General Navigation

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/spezifisch/stmps/mpvplayer"
 	"github.com/spezifisch/stmps/subsonic"
+	"github.com/spf13/viper"
 )
 
 func (ui *Ui) handlePageInput(event *tcell.EventKey) *tcell.EventKey {
@@ -118,7 +119,9 @@ func (ui *Ui) ShowPage(name string) {
 
 func (ui *Ui) Quit() {
 	// TODO savePlayQueue/getPlayQueue
-	ui.queuePage.coverArtCache.Close()
+	if !viper.GetBool("ui.hide-song-info") {
+		ui.queuePage.coverArtCache.Close()
+	}
 	ui.player.Quit()
 	ui.app.Stop()
 }

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -118,6 +118,7 @@ func (ui *Ui) ShowPage(name string) {
 
 func (ui *Ui) Quit() {
 	// TODO savePlayQueue/getPlayQueue
+	ui.queuePage.coverArtCache.Close()
 	ui.player.Quit()
 	ui.app.Stop()
 }


### PR DESCRIPTION
Because of all the dependent changes, this is branched off concurrent-album-art.

This allows users to disable the song info pane by setting:

```toml
[ui]
hide-info-pane = true
```

While the pane can't be dynamically hidden, this code does completely disable the creation of resources needed to display the pane, image art, caching, and all of that overhead. I think this is sufficient to close #67