### PR TITLE
Feat 52 search by genre

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,16 @@ In any of the columns:
 - `Enter` / `a`: Adds the selected item recursively to the queue.
 - Left/right arrow keys (`←`, `→`) navigate between the columns
 - Up/down arrow keys (`↓`, `↑`) navigate the selected column list
+- `g`: toggle genre search
 
 In the search field:
 
 - `Enter`: Perform the query.
 - `Escape`: Escapes into the columns, where the global key bindings work.
 
-Note that the Search page is *not* a browser like the Browser page: it displays the search results returned by the server. Selecting a different artist will not change the album or song search results. OpenSubsonic servers implement the search function differently; in gonic, if you search for "black", you will get artists with "black" in their names in the artists column; albums with "black" in their titles in the albums column; and songs with "black" in their titles in the songs column. Navidrome appears to include all results with "black" anywhere in their IDv3 metadata. Since the API search results filteres these matches into sections -- artists, albums, and songs -- this means that, with Navidrome, you may see albums that don't have "black" in their names; maybe "black" is in their artist title.
+Note that the Search page is *not* a browser like the Browser page: it displays the search results returned by the server. Selecting a different artist will not change the album or song search results.
+
+In Genre Search mode, the genres known by the server are displayed in the middle column. Pressing `Enter` on one of these will load all of the songs with that genre in the third column. Searching with the search field will fill the third column with songs whose genres match the search. Searching for a genre by typing it in should return the same songs as selecting it in the middle column. Note that genre searches may (depending on your Subsonic server's search implementation) be case sensitive.
 
 ## Advanced Configuration and Features
 

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -191,6 +191,7 @@ func (ui *Ui) addSongToQueue(entity *subsonic.SubsonicEntity) {
 		TrackNumber: entity.Track,
 		CoverArtId:  entity.CoverArtId,
 		DiscNumber:  entity.DiscNumber,
+		Year:        entity.Year,
 	}
 	ui.player.AddToQueue(queueItem)
 }
@@ -206,6 +207,7 @@ func makeSongHandler(entity *subsonic.SubsonicEntity, ui *Ui, fallbackArtist str
 	track := entity.Track
 	coverArtId := entity.CoverArtId
 	disc := entity.DiscNumber
+	year := entity.Year
 
 	response, err := ui.connection.GetAlbum(entity.Parent)
 	album := ""
@@ -223,7 +225,7 @@ func makeSongHandler(entity *subsonic.SubsonicEntity, ui *Ui, fallbackArtist str
 	}
 
 	return func() {
-		if err := ui.player.PlayUri(id, uri, title, artist, album, duration, track, disc, coverArtId); err != nil {
+		if err := ui.player.PlayUri(id, uri, title, artist, album, duration, track, disc, coverArtId, year); err != nil {
 			ui.logger.PrintError("SongHandler Play", err)
 			return
 		}

--- a/help_text.go
+++ b/help_text.go
@@ -55,11 +55,9 @@ artist, album/genre, or song column
   g       toggle genre search
   /       start search
 In album tab
-  Enter/a recursively add item to quue
+  Enter   recursively add item to quue
 In genre tab
   Enter   shows songs with genre
-In song tab
-  Enter/a adds song to queue
 search field
   Enter   search for text
   Esc     cancel search

--- a/help_text.go
+++ b/help_text.go
@@ -47,13 +47,19 @@ a     add playlist or song to queue
 `
 
 const helpSearchPage = `
-artist, album, or song column
+artist, album/genre, or song column
   Down/Up navigate within the column
   Left    previous column
   Right   next column
   Enter/a recursively add item to quue
   g       toggle genre search
   /       start search
+In album tab
+  Enter/a recursively add item to quue
+In genre tab
+  Enter   shows songs with genre
+In song tab
+  Enter/a adds song to queue
 search field
   Enter   search for text
   Esc     cancel search

--- a/help_text.go
+++ b/help_text.go
@@ -52,6 +52,7 @@ artist, album, or song column
   Left    previous column
   Right   next column
   Enter/a recursively add item to quue
+  g       toggle genre search
   /       start search
 search field
   Enter   search for text

--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -125,8 +125,8 @@ func (p *Player) PlayNextTrack() error {
 	return nil
 }
 
-func (p *Player) PlayUri(id, uri, title, artist, album string, duration, track, disc int, coverArtId string) error {
-	p.queue = []QueueItem{{id, uri, title, artist, duration, album, track, coverArtId, disc}}
+func (p *Player) PlayUri(id, uri, title, artist, album string, duration, track, disc int, coverArtId string, year int) error {
+	p.queue = []QueueItem{{id, uri, title, artist, duration, album, track, coverArtId, disc, year}}
 	p.replaceInProgress = true
 	if ip, e := p.IsPaused(); ip && e == nil {
 		if err := p.Pause(); err != nil {

--- a/mpvplayer/queue_item.go
+++ b/mpvplayer/queue_item.go
@@ -17,6 +17,7 @@ type QueueItem struct {
 	TrackNumber int
 	CoverArtId  string
 	DiscNumber  int
+	Year        int
 }
 
 var _ remote.TrackInterface = (*QueueItem)(nil)
@@ -59,4 +60,8 @@ func (q QueueItem) GetTrackNumber() int {
 
 func (q QueueItem) GetDiscNumber() int {
 	return q.DiscNumber
+}
+
+func (q QueueItem) GetYear() int {
+	return q.Year
 }

--- a/page_playlist.go
+++ b/page_playlist.go
@@ -251,11 +251,6 @@ func (p *PlaylistPage) UpdatePlaylists() {
 			stop <- true
 			return
 		}
-		if response == nil {
-			p.logger.Printf("no error from GetPlaylists, but also no response!")
-			stop <- true
-			return
-		}
 		p.updatingMutex.Lock()
 		defer p.updatingMutex.Unlock()
 		p.ui.playlists = response.Playlists.Playlists

--- a/page_queue.go
+++ b/page_queue.go
@@ -268,6 +268,7 @@ func (q *QueuePage) updateQueue() {
 		q.queueList.ScrollToBeginning()
 	}
 
+	q.queueList.Box.SetTitle(fmt.Sprintf(" queue (%d) ", q.queueList.GetRowCount()))
 	r, c := q.queueList.GetSelection()
 	q.changeSelection(r, c)
 }

--- a/page_search.go
+++ b/page_search.go
@@ -114,6 +114,9 @@ func (ui *Ui) createSearchPage() *SearchPage {
 			searchPage.ui.app.SetFocus(searchPage.searchField)
 			return nil
 		case 'g':
+			searchPage.albumList.Clear()
+			searchPage.artistList.Clear()
+			searchPage.songList.Clear()
 			if searchPage.queryGenre {
 				searchPage.albumList.SetTitle(" album matches ")
 			} else {
@@ -179,6 +182,9 @@ func (ui *Ui) createSearchPage() *SearchPage {
 			searchPage.ui.app.SetFocus(searchPage.searchField)
 			return nil
 		case 'g':
+			searchPage.albumList.Clear()
+			searchPage.artistList.Clear()
+			searchPage.songList.Clear()
 			if searchPage.queryGenre {
 				searchPage.albumList.SetTitle(" album matches ")
 			} else {
@@ -223,6 +229,9 @@ func (ui *Ui) createSearchPage() *SearchPage {
 			searchPage.ui.app.SetFocus(searchPage.searchField)
 			return nil
 		case 'g':
+			searchPage.albumList.Clear()
+			searchPage.artistList.Clear()
+			searchPage.songList.Clear()
 			if searchPage.queryGenre {
 				searchPage.albumList.SetTitle(" album matches ")
 			} else {
@@ -253,6 +262,7 @@ func (ui *Ui) createSearchPage() *SearchPage {
 
 			queryStr := searchPage.searchField.GetText()
 			search <- queryStr
+			searchPage.aproposFocus()
 		default:
 			return event
 		}

--- a/page_search.go
+++ b/page_search.go
@@ -218,7 +218,6 @@ func (s *SearchPage) search(search chan string) {
 			artOff = 0
 			albOff = 0
 			songOff = 0
-			s.logger.Printf("searching for %q [%d, %d, %d]", query, artOff, albOff, songOff)
 			for len(more) > 0 {
 				<-more
 			}
@@ -226,7 +225,6 @@ func (s *SearchPage) search(search chan string) {
 				continue
 			}
 		case <-more:
-			s.logger.Printf("fetching more %q [%d, %d, %d]", query, artOff, albOff, songOff)
 		}
 		res, err := s.ui.connection.Search(query, artOff, albOff, songOff)
 		if err != nil {
@@ -265,6 +263,10 @@ func (s *SearchPage) search(search chan string) {
 			s.songList.Box.SetTitle(fmt.Sprintf(" song matches (%d) ", len(s.songs)))
 		})
 
+		// Only do this the one time, to prevent loops from stealing the user's focus
+		if artOff == 0 && albOff == 0 && songOff == 0 {
+			s.aproposFocus()
+		}
 		artOff += len(res.SearchResults.Artist)
 		albOff += len(res.SearchResults.Album)
 		songOff += len(res.SearchResults.Song)

--- a/page_search.go
+++ b/page_search.go
@@ -267,6 +267,7 @@ func (s *SearchPage) search(search chan string) {
 		if artOff == 0 && albOff == 0 && songOff == 0 {
 			s.aproposFocus()
 		}
+
 		artOff += len(res.SearchResults.Artist)
 		albOff += len(res.SearchResults.Album)
 		songOff += len(res.SearchResults.Song)

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -131,6 +131,16 @@ type PlayQueue struct {
 	Entries  SubsonicEntities `json:"entry"`
 }
 
+type GenreEntries struct {
+	Genres []GenreEntry `json:"genre"`
+}
+
+type GenreEntry struct {
+	SongCount  int    `json:"songCount"`
+	AlbumCount int    `json:"albumCount"`
+	Name       string `json:"value"`
+}
+
 type Artist struct {
 	Id         string  `json:"id"`
 	Name       string  `json:"name"`
@@ -278,6 +288,8 @@ type SubsonicResponse struct {
 	SearchResults SubsonicResults   `json:"searchResult3"`
 	ScanStatus    ScanStatus        `json:"scanStatus"`
 	PlayQueue     PlayQueue         `json:"playQueue"`
+	Genres        GenreEntries      `json:"genres"`
+	SongsByGenre  SubsonicSongs     `json:"songsByGenre"`
 }
 
 type responseWrapper struct {
@@ -687,4 +699,31 @@ func (connection *SubsonicConnection) LoadPlayQueue() (*SubsonicResponse, error)
 	query := defaultQuery(connection)
 	requestUrl := fmt.Sprintf("%s/rest/getPlayQueue?%s", connection.Host, query.Encode())
 	return connection.getResponse("GetPlayQueue", requestUrl)
+}
+
+func (connection *SubsonicConnection) GetGenres() (*SubsonicResponse, error) {
+	query := defaultQuery(connection)
+	requestUrl := connection.Host + "/rest/getGenres" + "?" + query.Encode()
+	resp, err := connection.getResponse("GetGenres", requestUrl)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (connection *SubsonicConnection) GetSongsByGenre(genre string, offset int, musicFolderID string) (*SubsonicResponse, error) {
+	query := defaultQuery(connection)
+	query.Add("genre", genre)
+	if offset != 0 {
+		query.Add("offset", strconv.Itoa(offset))
+	}
+	if musicFolderID != "" {
+		query.Add("musicFolderId", musicFolderID)
+	}
+	requestUrl := connection.Host + "/rest/getSongsByGenre" + "?" + query.Encode()
+	resp, err := connection.getResponse("GetPlaylists", requestUrl)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }

--- a/subsonic/api.go
+++ b/subsonic/api.go
@@ -193,6 +193,7 @@ type SubsonicEntity struct {
 	DiscNumber  int      `json:"discNumber"`
 	Path        string   `json:"path"`
 	CoverArtId  string   `json:"coverArt"`
+	Year        int      `json:"year"`
 }
 
 func (s SubsonicEntity) ID() string {


### PR DESCRIPTION
# This is forked off issue-76-clarify-search-results!!!

It's branched here because, otherwise, the merge for both will be nasty. It's a **separate** branch, because it adds a feature.

This implements #52. 

- It works better with the feature that focuses the columns rather than the search field.
- It's _in_ the search page; this is largely to prevent the proliferation of pages
- Pressing 'g' in any column toggles between genre search, and a general `search3` search
- Genre searches _only_ return songs (that's an API thing). This means the artist and album fields are unused, which leads to....
- in genre-search mode, the album field is renamed to "genres" and is filled with a list of genres the server knows, pulled by `/getGenres`
- Selecting a genre from the middle column is the same as searching for that genre, and fills the songs column with songs with that genre.
- Genre searches are case sensitive, on both gonic and Navidrome.
- An entire genre can be added to the queue with `a`

I try to keep commits focused, but this commit changes a couple of other (unrelated) things:

- I added Year to the song info metadata. I originally wanted to include the genre, but most of the API calls returning song info do _not_ include the genre with the song; when included, it's in the album info. A work-around would have been far more invasive, so I've put it off, but I kept the Year change.
- The Queue page now show the size of the queue in the column title. I originally did this to test that queue population was adding the right number of things, and because
- I started expanding column counts in the search page, and liked it. I think ultimately I'd like to add it to **all** lists.

You _should_ be able to merge "clarify" and then merge this branch; or if you decide to merge both, just merge this branch and you'll get both.