### PR TITLE
change: re-arranges the song info; purely aesthic chang

### DIFF
--- a/page_queue.go
+++ b/page_queue.go
@@ -442,12 +442,12 @@ func (q *queueData) GetColumnCount() int {
 	return queueDataColumns
 }
 
-var songInfoTemplateString = `[blue::b]Title:[-:-:-:-] [green::i]{{.Title}}[-:-:-:-]
+var songInfoTemplateString = `[blue::b]Title:[-:-:-:-] [green::i]{{.Title}}[-:-:-:-] [yellow::i]({{formatTime .Duration}})[-:-:-:-]
 [blue::b]Artist:[-:-:-:-] [::i]{{.Artist}}[-:-:-:-]
 [blue::b]Album:[-:-:-:-] [::i]{{.GetAlbum}}[-:-:-:-]
-[blue::b]Disc:[-:-:-:-] [::i]{{.GetDiscNumber}}[-:-:-:-]
-[blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]
-[blue::b]Duration:[-:-:-:-] [::i]{{formatTime .Duration}}[-:-:-:-] `
+[blue::b]Disc:[-:-:-:-] [::i]{{.GetDiscNumber}}[-:-:-:-]  [blue::b]Track:[-:-:-:-] [::i]{{.GetTrackNumber}}[-:-:-:-]
+[blue::b]Year:[-:-:-:-] [::i]{{.GetYear}}[-:-:-:-]
+`
 
 //go:embed docs/stmps_logo.png
 var _stmps_logo []byte


### PR DESCRIPTION
Purely cosmetic change in the song info panel: compresses the information to take less space. This is a change to only the template.

| Old | New |
|-----|-----|
| ![2024-10-21-091348_380x487_scrot](https://github.com/user-attachments/assets/fff69ead-7f2a-4ff4-8523-f3998a6255f7) | ![2024-10-21-091212_405x417_scrot](https://github.com/user-attachments/assets/77792522-2a7a-4b8b-bc03-a47f1047e01e) |

(The screenshot size difference is only because I snapped them in different terminals).