### PR TITLE
fix: issue #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These controls are accessible from any view:
 - `-`/`=`: Volume down/volume up
 - `,`/`.`: Seek -10/+10 seconds
 - `r`: Add 50 random songs to the queue
-- `s`: Start a server library scan
+- `c`: Start a server library scan
 
 ### Browser Controls
 

--- a/gui_handlers.go
+++ b/gui_handlers.go
@@ -101,7 +101,7 @@ func (ui *Ui) handlePageInput(event *tcell.EventKey) *tcell.EventKey {
 		}
 		ui.queuePage.UpdateQueue()
 
-	case 's':
+	case 'c':
 		if err := ui.connection.StartScan(); err != nil {
 			ui.logger.PrintError("startScan:", err)
 		}

--- a/help_text.go
+++ b/help_text.go
@@ -10,7 +10,7 @@ P      stop
 -/=(+) volume down/volume up
 ,/.    seek -10/+10 seconds
 r      add 50 random songs to queue
-s      start server library scan
+c      start server library sCan
 `
 
 const helpPageBrowser = `


### PR DESCRIPTION
Fixes #88 

"Start scan" is newer than "Save queue as playlist", so the hotkey for the former is changed to 'c'