### PR TITLE
Fix load queue seeking

### DIFF
--- a/mpvplayer/player.go
+++ b/mpvplayer/player.go
@@ -151,6 +151,11 @@ func (p *Player) IsSongLoaded() (bool, error) {
 	return !idle, err
 }
 
+func (p *Player) IsSeekable() (bool, error) {
+	seekable, err := p.getPropertyBool("seekable")
+	return seekable, err
+}
+
 func (p *Player) IsPaused() (bool, error) {
 	pause, err := p.getPropertyBool("pause")
 	return pause, err

--- a/page_queue.go
+++ b/page_queue.go
@@ -127,10 +127,16 @@ func (ui *Ui) createQueuePage() *QueuePage {
 						if err := ui.player.Play(); err != nil {
 							queuePage.logger.Printf("error playing: %s", err)
 						}
+						_ = ui.player.Pause()
+						for {
+							if seekable, err := ui.player.IsSeekable(); err == nil && seekable {
+								break
+							}
+							time.Sleep(100 * time.Millisecond)
+						}
 						if err = ui.player.Seek(ssr.PlayQueue.Position); err != nil {
 							queuePage.logger.Printf("unable to seek to position %s: %s", time.Duration(ssr.PlayQueue.Position)*time.Second, err)
 						}
-						_ = ui.player.Pause()
 					}
 				}()
 


### PR DESCRIPTION
Mpv requires the file's sample table to be loaded before any seek commands are considered valid. IsSongLoaded was insufficient since mpv stops being idle before the file is ready, and before mpv allows seek commands to work. The original plan was to wait on the "file-loaded" event, but turns out mpv has the `seekable` property, which makes this trivial.

This checks if mpv has entered a seekable state every 100ms. The error still needs to be logged and handled since it _can_ loop infinitely.

See https://github.com/spezifisch/stmps/pull/71#issuecomment-2555555235 for context.